### PR TITLE
Update MainGreedy.java

### DIFF
--- a/src/ru/arhiser/knapsack/MainGreedy.java
+++ b/src/ru/arhiser/knapsack/MainGreedy.java
@@ -20,21 +20,21 @@ public class MainGreedy {
 
         while (!indexes.isEmpty()) {
             int maxValue = prices[indexes.get(0)];
-            int maxIndex = indexes.get(0);
+            int maxIndex = 0;
 
             for (int i = 1; i < indexes.size(); i++) {
                 if (maxValue < prices[indexes.get(i)]) {
                     maxValue = prices[indexes.get(i)];
-                    maxIndex = indexes.get(i);
+                    maxIndex = i;
                 }
             }
 
-            resultWeight += weights[maxIndex];
-            if (resultWeight > maxWeight) {
-                break;
+            if (maxWeight - resultWeight >= weights[indexes.get(maxIndex)]) { //добавляем позицию, только если есть свободное место для неё.
+                resultWeight += weights[indexes.get(maxIndex)];
+                result.add(indexes.get(maxIndex));
+                if (resultWeight == maxWeight) break; //если ничего нельзя добавить, прерываем цикл.
             }
 
-            result.add(maxIndex);
             indexes.remove(maxIndex);
         }
 
@@ -42,5 +42,7 @@ public class MainGreedy {
         for (Integer integer : result) {
             System.out.println(integer + 1);
         }
+        System.out.println("total weight: " + resultWeight);
+        System.out.println("total backpack value: " + result.stream().mapToInt(x -> prices[x]).sum());
     }
 }


### PR DESCRIPTION
При тестировании обнаружил две ошибки:
- Если мы устанавливаем вес всех артикулов {1, 1, 1, 1, 1}, то будет ошибка из-за некорректных индексов. Предметы добавятся несколько раз.
- Если мы устанавливаем у самого дорогого предмета вес, который превышает максимальный, то программа останавливается, не продолжая искать другие предметы. Например, если 4-й предмет со стоимостью 7 сделать весом не 8 кг, а 80, то программа остановится, вес рюкзака будет 0.
Предлагаемые изменения:
1) 23, 28, 32-34, решают вопрос с некорректной работой индексов.
2) 32 - Добавляем позицию в рюкзак, только если для неё есть свободное место (вес) и продолжаем проверять другие позиции.
3) 45-46 - просто для облегчения проверки.
